### PR TITLE
Use modern syntax for dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ repositories {
     jcenter()
 }
 
-compile group: 'com.adamratzman', name: 'spotify-api-kotlin-core', version: '3.2.15'
+implementation("com.adamratzman:spotify-api-kotlin-core:3.2.15")
 ```
 
 Note that images and profiles are not supported on the Kotlin/JS target.


### PR DESCRIPTION
This syntax is compatible with Kotlin and Groovy. 
Therefore it is easier for new users to just copy and paste the dependency.