### PR TITLE
Fixed issue with browser launching for SpotifyPkceLogin

### DIFF
--- a/src/androidMain/kotlin/com/adamratzman/spotify/auth/pkce/AbstractSpotifyPkceLoginActivity.kt
+++ b/src/androidMain/kotlin/com/adamratzman/spotify/auth/pkce/AbstractSpotifyPkceLoginActivity.kt
@@ -86,10 +86,15 @@ public abstract class AbstractSpotifyPkceLoginActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.spotify_pkce_auth_layout)
 
-        authorizationIntent = Intent(Intent.ACTION_VIEW, getAuthorizationUrl())
         credentialStore = application.getDefaultCredentialStore(clientId, redirectUri)
 
-        startActivity(authorizationIntent)
+        // This activity is recreated on every launch, therefore we need to make sure not to
+        // launch the activity when a Spotify intent result has been received
+        if (intent?.isSpotifyPkceAuthIntent(redirectUri) == false) {
+            authorizationIntent = Intent(Intent.ACTION_VIEW, getAuthorizationUrl())
+            startActivity(authorizationIntent)
+            finish()
+        }
     }
 
     /**


### PR DESCRIPTION
When using the `AbstractSpotifyPkceLoginActivity`, I stumbled upon issues regarding the launch of the browser. In this activity, specifically in the `onCreate`, a `startActivity` is used to open the browser and authenticate the user. When the user finishes in the browser, the app will be opened again. The problem I encountered was the re-opening of the browser, because this happens in the `onCreate`. I've added a check so it won't open the browser if a Spotify intent has been received, which helped solve the issue.

I have also added `finish()`, which I mainly did because of one reason: if the user gets the option to choose which browser to open, but the user dismisses the dialog, a black activity will remain. Because the activity is recreated after you've been in the browser, the best way to solve this issue is by finishing the activity after you've called `startActivity`.