### PR TITLE
Add a note about Java8 API desugaring on Android

### DIFF
--- a/README_ANDROID.md
+++ b/README_ANDROID.md
@@ -315,3 +315,7 @@ class ViewBroadcastsActivity : BaseActivity() {
 }
 
 ```
+
+## Compatibility below Android API26
+
+Older versions of Android do not include some of the required Java8 APIs. To target these older APIs, you must enable [Java8 API Desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) in your app.


### PR DESCRIPTION
Thank you for the excellent library! It underpins the seamless Spotify integration in my app, and I truly appreciate the hard work in designing an ergonomic API!

Some of my users on Android version 7 (API24) phones have experienced some crashes in `Utils.getCurrentTimeMs` after upgrading from `spotify-api-kotlin-android:3.5.02` to `spotify-api-kotlin-android:3.7.0`. I think Java8 API desugaring is one way to fix it, so here's a link to instructions on how to enable it.

Would it be possible to go back to using `DateTime.nowUnixLong()` or to use `System.currentTimeMillis()` directly for Android builds at least? I think [this commit](https://github.com/adamint/spotify-web-api-kotlin/commit/48003f97123271f53bb1fc78b10b3d8392d1103a#diff-e73b11d0c0656ec5083df71cc4836cf0015e2ce27e6df4a1a03de62d9d53c7d1) is when it changed, and I can provide a PR, but wasn't sure what the context was.