### PR TITLE
temporarily disable client player api tests due to flakiness

### DIFF
--- a/src/commonTest/kotlin/com.adamratzman/spotify/TestUtilities.kt
+++ b/src/commonTest/kotlin/com.adamratzman/spotify/TestUtilities.kt
@@ -4,7 +4,7 @@ package com.adamratzman.spotify
 abstract class AbstractTest<T : GenericSpotifyApi> {
     var api: T? = null
 
-    fun testPrereq() = api != null
+    open fun testPrereq() = api != null
 
     suspend inline fun <reified Z : T> build(): Boolean {
         return try {

--- a/src/commonTest/kotlin/com.adamratzman/spotify/priv/ClientPlayerApiTest.kt
+++ b/src/commonTest/kotlin/com.adamratzman/spotify/priv/ClientPlayerApiTest.kt
@@ -3,6 +3,7 @@ package com.adamratzman.spotify.priv
 
 import com.adamratzman.spotify.AbstractTest
 import com.adamratzman.spotify.SpotifyClientApi
+import com.adamratzman.spotify.getEnvironmentVariable
 import com.adamratzman.spotify.models.CurrentlyPlayingType
 import com.adamratzman.spotify.models.PlayableUri
 import com.adamratzman.spotify.models.SpotifyContextType
@@ -25,6 +26,10 @@ import kotlinx.coroutines.delay
 
 @ExperimentalTime
 class ClientPlayerApiTest : AbstractTest<SpotifyClientApi>() {
+    override fun testPrereq(): Boolean {
+        return super.testPrereq() && getEnvironmentVariable("SPOTIFY_ENABLE_PLAYER_TESTS")?.toBoolean() == true
+    }
+
     @Test
     fun testGetDevices() {
         return runBlockingTest {


### PR DESCRIPTION
Signed-off-by: Adam Ratzman <adam@adamratzman.com>