### PR TITLE
Add a from_token Market for some Spotify endpoints

### DIFF
--- a/src/commonMain/kotlin/com.adamratzman.spotify/utils/Market.kt
+++ b/src/commonMain/kotlin/com.adamratzman.spotify/utils/Market.kt
@@ -1844,7 +1844,12 @@ public enum class Market(
      * [Zimbabwe](http://en.wikipedia.org/wiki/Zimbabwe)
      * [Market Code: ZW](http://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#ZW)
      */
-    ZW("Zimbabwe", "ZWE", 716, Assignment.OFFICIALLY_ASSIGNED);
+    ZW("Zimbabwe", "ZWE", 716, Assignment.OFFICIALLY_ASSIGNED),
+
+    /**
+     * A special Market for endpoints to return content available in the user's own market
+     */
+    from_token("from_token", "ZZZ", 999, Assignment.NOT_USED);
 
     /**
      * Code assignment state in [ISO 3166-1](http://en.wikipedia.org/wiki/ISO_3166-1).


### PR DESCRIPTION
According to https://developer.spotify.com/documentation/general/guides/track-relinking-guide/
the special string `from_token` can be provided instead of providing a manual country code
to locate content based on the logged-in user's own country.