### PR TITLE
Fixed #302: PlayHistory should contain a Track object rather than a SimpleTrack, due to a change in the Spotify API

### DIFF
--- a/src/commonMain/kotlin/com.adamratzman.spotify/models/Player.kt
+++ b/src/commonMain/kotlin/com.adamratzman.spotify/models/Player.kt
@@ -37,7 +37,7 @@ public data class SpotifyContext(
  */
 @Serializable
 public data class PlayHistory(
-    val track: SimpleTrack,
+    val track: Track,
     @SerialName("played_at") val playedAt: String,
     val context: SpotifyContext? = null
 )


### PR DESCRIPTION
Closes #302