### PR TITLE
Updated EncryptedSharedPreferences and moved getSpotifyClientPkceApi to a suspend fun

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -326,7 +326,7 @@ tasks {
     spotless {
         kotlin {
             target("**/*.kt")
-            licenseHeader("/* Spotify Web API, Kotlin Wrapper; MIT License, 2017-2022; Original author: Adam Ratzman */")
+            licenseHeader("/* Spotify Web API, Kotlin Wrapper; MIT License, 2017-2023; Original author: Adam Ratzman */")
             ktlint()
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 # language dependencies
-kotlinVersion=1.9.10
+kotlinVersion=1.9.20
 
 # library dependencies
 kotlinxDatetimeVersion=0.4.1
@@ -19,7 +19,7 @@ kotlinxCoroutinesVersion=1.7.3
 
 androidBuildToolsVersion=8.1.0
 androidSpotifyAuthVersion=2.1.0
-androidCryptoVersion=1.0.0
+androidCryptoVersion=1.1.0-alpha06
 androidxCompatVersion=1.6.1
 
 sparkVersion=2.9.4


### PR DESCRIPTION
# Why
I'm making my app's remake (called Spowlo) and I'm really dependant on this library. I really love it, but there are some things like the ones I have added here for trying to improve it a little bit.
The library makes my app crash and really unstable at the hour of creating the PKCE client (and also using it), as well as a very large ammount of time (like 5-7 seconds) for creating the client API, while blocking the main thread of the app.

# What I have made?
- Updated the androidx.security.crypto library for updating the EncryptedSharedPreferences function in a modern way and non-deprecated.
- Made the getSpotifyClientPkceApi function suspend and deleted the runBlocking blocks, so the user can choose the thread that he wants to run the function; anyways this can be changed.