### PR TITLE
Add RefreshTokenExpiredException

### DIFF
--- a/src/commonMain/kotlin/com.adamratzman.spotify/SpotifyApi.kt
+++ b/src/commonMain/kotlin/com.adamratzman.spotify/SpotifyApi.kt
@@ -713,6 +713,8 @@ internal suspend fun executeTokenRequest(
  * @param clientSecret The Spotify application client secret (not needed for PKCE).
  * @param refreshToken The refresh token.
  * @param usesPkceAuth Whether this token was created using PKCE auth or not.
+ *
+ * @throws [SpotifyException.RefreshTokenExpiredException] if the refresh token has expired after 6 months.
  */
 public suspend fun refreshSpotifyClientToken(
     clientId: String,
@@ -760,6 +762,8 @@ public suspend fun refreshSpotifyClientToken(
 
     return if (response.responseCode in 200..399) {
         response.body.toObject(Token.serializer(), null, nonstrictJson)
+    } else if(response.responseCode == 400 && response.body.contains("invalid_grant")) {
+        throw SpotifyException.RefreshTokenExpiredException()
     } else {
         throw BadRequestException(
             response.body.toObject(

--- a/src/commonMain/kotlin/com.adamratzman.spotify/SpotifyException.kt
+++ b/src/commonMain/kotlin/com.adamratzman.spotify/SpotifyException.kt
@@ -81,4 +81,13 @@ public sealed class SpotifyException(message: String, cause: Throwable? = null) 
             cause = cause,
             message = "You tried to call a method that requires the following missing scopes: $missingScopes. Please make sure that your token is requested with these scopes."
         )
+
+    /**
+     * Exception signifying that the current refresh token has expired.
+     * Refreh tokens are only valid for 6 months, after which they must be refreshed by prompting the user to re-authorize.
+     *
+     * * **[Api Reference](https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration)**
+     */
+    public class RefreshTokenExpiredException(message: String? = null, cause: Throwable? = null) :
+        SpotifyException(message ?: "Refresh token has expired, user needs to re-authorize", cause)
 }


### PR DESCRIPTION
This PR addresses the upcoming refresh token expiration after 6 months as announced [here](https://developer.spotify.com/blog/2026-06-18-refresh-token-expiration) after July 20, 2026.
It merely adds a RefreshTokenExpiredException - the implementation of re-authorization via the user cannot be further automated and needs to be handled by each application differently.